### PR TITLE
Make dv an executable script

### DIFF
--- a/dv
+++ b/dv
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 ## dv.R -- command line devtools wrapper
 VERSION <- "0.01"
 quiet <- suppressPackageStartupMessages


### PR DESCRIPTION
- Use #!/usr/bin/env to find Rscript in PATH
- Set the execute bit: change the mode to 0755.
- Rename dv.R to dv

These three changes make the use of an alias unnecessary.
Simply install dv in any directory found in the user's PATH, such as:
`cp dv ~/bin/`
